### PR TITLE
Finish updating `region` column of `employees` table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ The changes to the database itself can be found [here](https://github.com/andrew
 - [x] Finish the queries from [geeksengine.com](https://www.geeksengine.com/database/problem-solving/northwind-queries-part-1.php)
 - [ ] Update the regions used in the database to use the four main regions of the world (EMEA, NA, LATAM, APAC)<br>
     - [ ] Tables to Update<br>
-        - [ ] Territories<br>
         - [ ] Employees<br>
         - [ ] Orders<br>
         - [ ] Customers<br>
+        - [x] Territories<br>
         - [x] Region<br>
         - [x] Suppliers<br>
 - [x] Add new territories based on the cities of the `orders` table

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -250,16 +250,15 @@ CREATE TABLE employees_updated (
 );
 
 SELECT * FROM employees_updated;
-
+SELECT * FROM employee_territories;
 DROP TABLE employees;
 
-ALTER TABLE orders
-DROP FOREIGN KEY orders_ibfk_2;
+ALTER TABLE employee_territories
+DROP FOREIGN KEY employee_territories_ibfk_2;
 
 SELECT * FROM orders;
 
-ALTER TABLE orders
-ADD CONSTRAINT orders_ibfk_2
+ALTER TABLE employee_territories
+ADD CONSTRAINT employee_territories_ibfk_2
 FOREIGN KEY (employee_id)
 REFERENCES employees_updated (employee_id);
-

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -249,18 +249,7 @@ CREATE TABLE employees_updated (
     PRIMARY KEY (employee_id)
 );
 
+UPDATE employees
+SET region = 1
+WHERE employee_id = 5 OR employee_id = 6 OR employee_id = 7 OR employee_id = 9;
 SELECT * FROM employees;
-SELECT * FROM employee_territories;
-DROP TABLE employees;
-
-RENAME TABLE employees_updated TO employees;
-
-ALTER TABLE employee_territories
-DROP FOREIGN KEY employee_territories_ibfk_2;
-
-SELECT * FROM orders;
-
-ALTER TABLE employee_territories
-ADD CONSTRAINT employee_territories_ibfk_2
-FOREIGN KEY (employee_id)
-REFERENCES employees_updated (employee_id);

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -249,9 +249,11 @@ CREATE TABLE employees_updated (
     PRIMARY KEY (employee_id)
 );
 
-SELECT * FROM employees_updated;
+SELECT * FROM employees;
 SELECT * FROM employee_territories;
 DROP TABLE employees;
+
+RENAME TABLE employees_updated TO employees;
 
 ALTER TABLE employee_territories
 DROP FOREIGN KEY employee_territories_ibfk_2;

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -249,7 +249,11 @@ CREATE TABLE employees_updated (
     PRIMARY KEY (employee_id)
 );
 
+INSERT INTO employees_updated (employee_id, last_name, first_name, title, title_of_courtesy, birth_date, hire_date, address, city, state, postal_code, country, region, home_phone, extension, photo, notes, reports_to, photo_path)
+SELECT employee_id, last_name, first_name, title, title_of_courtesy, birth_date, hire_date, address, city, state, postal_code, country, region, home_phone, extension, photo, notes, reports_to, photo_path
+FROM employees;
 
+SELECT * FROM employees_updated;
 
 DESCRIBE employees;
 

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -224,22 +224,38 @@ WHERE orders.ship_region IS NOT NULL;
 -- Add region to both tables; fill in with world regions
 -- Add some orders with the APAC region
 SET SQL_SAFE_UPDATES = 0;
-SELECT * FROM territories;
-
-SELECT * FROM suppliers
-ORDER BY region;
-
 SELECT * FROM employees;
 
-UPDATE territories
-SET territories.territory_description = 'Westborough'
-WHERE territories.territory_id = 02139;
+CREATE TABLE employees_updated (
+	employee_id SMALLINT,
+    last_name VARCHAR(20) NOT NULL,
+    first_name VARCHAR(20) NOT NULL,
+    title VARCHAR(30),
+    title_of_courtesy VARCHAR(25),
+    birth_date DATE,
+    hire_date DATE,
+    address VARCHAR(60),
+    city VARCHAR(15),
+    state VARCHAR(15),
+    postal_code VARCHAR(10),
+    country VARCHAR(15),
+    region SMALLINT,
+    home_phone VARCHAR(24),
+    extension VARCHAR(4),
+    photo BLOB,
+    notes TEXT,
+    reports_to SMALLINT,
+    photo_path VARCHAR(255),
+    PRIMARY KEY (employee_id)
+);
 
-UPDATE territories
-SET territories.region_id = 2
-WHERE territories.territory_id = 03049;
 
 
+DESCRIBE employees;
+
+ALTER TABLE employees
+CHANGE region state VARCHAR(15);
+DESCRIBE employees;
 
 SELECT orders.ship_city, orders.ship_region, orders.ship_country
 FROM orders;

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -249,19 +249,17 @@ CREATE TABLE employees_updated (
     PRIMARY KEY (employee_id)
 );
 
-INSERT INTO employees_updated (employee_id, last_name, first_name, title, title_of_courtesy, birth_date, hire_date, address, city, state, postal_code, country, region, home_phone, extension, photo, notes, reports_to, photo_path)
-SELECT employee_id, last_name, first_name, title, title_of_courtesy, birth_date, hire_date, address, city, state, postal_code, country, region, home_phone, extension, photo, notes, reports_to, photo_path
-FROM employees;
-
 SELECT * FROM employees_updated;
 
-DESCRIBE employees;
+DROP TABLE employees;
 
-ALTER TABLE employees
-CHANGE region state VARCHAR(15);
-DESCRIBE employees;
+ALTER TABLE orders
+DROP FOREIGN KEY orders_ibfk_2;
 
-SELECT orders.ship_city, orders.ship_region, orders.ship_country
-FROM orders;
+SELECT * FROM orders;
 
-SELECT * FROM suppliers;
+ALTER TABLE orders
+ADD CONSTRAINT orders_ibfk_2
+FOREIGN KEY (employee_id)
+REFERENCES employees_updated (employee_id);
+


### PR DESCRIPTION
Initially, the `employees` table did not include a `region` column.

To create a `region` column in the `employees` table, I created a new table with the additional column placed where needed. Then, the values from the original `employees` table were copied over to the new table. Before deleting the original `employees` table, I updated the foreign key references. Then, the original `employees` table was deleted. Finally, I added all of the corresponding region values to the `employees` table.