### PR TITLE
Add new `orders` table with `ship_region` column

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The changes to the database itself can be found [here](https://github.com/andrew
 - [x] Add new territories based on the cities of the `orders` table
 - [x] Update `region` column in `customers` table to `state`
 - [x] Add `region` column to `customers` table; use the new world regions
-- [ ] Update `ship_region` column in `orders` table to `state`
+- [x] Update `ship_region` column in `orders` table to `state`
 - [ ] Add `ship_region` column to `orders` table; use the new world regions
 - [x] Update `region` column in `employees` table to `state`
 - [x] Add `region` column to `employees` table; use the new world regions

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -225,41 +225,15 @@ WHERE orders.ship_region IS NOT NULL;
 -- Add some orders with the APAC region
 SET SQL_SAFE_UPDATES = 0;
 
-ALTER TABLE orders RENAME COLUMN ship_region TO state;
+SHOW CREATE TABLE order_details;
 
-CREATE TABLE `orders_updated` (
-  `order_id` smallint NOT NULL,
-  `customer_id` char(5) DEFAULT NULL,
-  `employee_id` smallint DEFAULT NULL,
-  `order_date` date DEFAULT NULL,
-  `required_date` date DEFAULT NULL,
-  `shipped_date` date DEFAULT NULL,
-  `ship_via` smallint DEFAULT NULL,
-  `freight` decimal(10,2) DEFAULT NULL,
-  `ship_name` varchar(40) DEFAULT NULL,
-  `ship_address` varchar(60) DEFAULT NULL,
-  `ship_city` varchar(15) DEFAULT NULL,
-  `ship_state` varchar(15) DEFAULT NULL,
-  `ship_region` smallint DEFAULT NULL,
-  `ship_postal_code` varchar(10) DEFAULT NULL,
-  `ship_country` varchar(15) DEFAULT NULL,
-  PRIMARY KEY (`order_id`),
-  KEY `customer_id` (`customer_id`),
-  KEY `ship_via` (`ship_via`),
-  KEY `orders_ibfk_2` (`employee_id`),
-  CONSTRAINT `orders_ibfk_1` FOREIGN KEY (`customer_id`) REFERENCES `customers` (`customer_id`),
-  CONSTRAINT `orders_ibfk_2` FOREIGN KEY (`employee_id`) REFERENCES `employees` (`employee_id`),
-  CONSTRAINT `orders_ibfk_3` FOREIGN KEY (`ship_via`) REFERENCES `shippers` (`shipper_id`)
-);
+-- Remove constraint from order_details
+-- Add new constraint to order_details that references the new orders table
+ALTER TABLE order_details
+ADD CONSTRAINT order_details_ibfk_2
+FOREIGN KEY (order_id)
+REFERENCES orders (order_id);
 
+SELECT * FROM orders;
 
-INSERT INTO orders_updated
-SELECT order_id, customer_id, employee_id, order_date, required_date, shipped_date, ship_via, freight, ship_name, ship_address, ship_city, state, NULL, ship_postal_code, ship_country
-FROM orders;
-
-SELECT * FROM orders_updated;
-
-SELECT order_id
-FROM orders
-JOIN orders_updated ON orders
 

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -225,14 +225,41 @@ WHERE orders.ship_region IS NOT NULL;
 -- Add some orders with the APAC region
 SET SQL_SAFE_UPDATES = 0;
 
-SELECT * FROM customers
-ORDER BY country;
+ALTER TABLE orders RENAME COLUMN ship_region TO state;
 
-UPDATE customers
-SET region = 2
-WHERE country = 'Canada' OR country = 'USA';
+CREATE TABLE `orders_updated` (
+  `order_id` smallint NOT NULL,
+  `customer_id` char(5) DEFAULT NULL,
+  `employee_id` smallint DEFAULT NULL,
+  `order_date` date DEFAULT NULL,
+  `required_date` date DEFAULT NULL,
+  `shipped_date` date DEFAULT NULL,
+  `ship_via` smallint DEFAULT NULL,
+  `freight` decimal(10,2) DEFAULT NULL,
+  `ship_name` varchar(40) DEFAULT NULL,
+  `ship_address` varchar(60) DEFAULT NULL,
+  `ship_city` varchar(15) DEFAULT NULL,
+  `ship_state` varchar(15) DEFAULT NULL,
+  `ship_region` smallint DEFAULT NULL,
+  `ship_postal_code` varchar(10) DEFAULT NULL,
+  `ship_country` varchar(15) DEFAULT NULL,
+  PRIMARY KEY (`order_id`),
+  KEY `customer_id` (`customer_id`),
+  KEY `ship_via` (`ship_via`),
+  KEY `orders_ibfk_2` (`employee_id`),
+  CONSTRAINT `orders_ibfk_1` FOREIGN KEY (`customer_id`) REFERENCES `customers` (`customer_id`),
+  CONSTRAINT `orders_ibfk_2` FOREIGN KEY (`employee_id`) REFERENCES `employees` (`employee_id`),
+  CONSTRAINT `orders_ibfk_3` FOREIGN KEY (`ship_via`) REFERENCES `shippers` (`shipper_id`)
+);
 
-DESCRIBE region;
-DESCRIBE customers;
-SHOW CREATE TABLE customers;
+
+INSERT INTO orders_updated
+SELECT order_id, customer_id, employee_id, order_date, required_date, shipped_date, ship_via, freight, ship_name, ship_address, ship_city, state, NULL, ship_postal_code, ship_country
+FROM orders;
+
+SELECT * FROM orders_updated;
+
+SELECT order_id
+FROM orders
+JOIN orders_updated ON orders
 


### PR DESCRIPTION
The `orders` table has been recreated with the `ship_region` column. The data has been copied over.