### PR TITLE
Create first order from the APAC region

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,6 @@ I'm in the process of reworking the database to use world regions. I am adding t
 - [x] Add `ship_region` column to `orders` table; use the new world regions
 - [x] Update `region` column in `employees` table to `state`
 - [x] Add `region` column to `employees` table; use the new world regions
+- [ ] Add some orders from APAC
+- [ ] Make some queries with the new data; top products per region, top salesperson per region, etc.
 <br>

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -227,13 +227,6 @@ SET SQL_SAFE_UPDATES = 1;
 SELECT * FROM employees;
 DESCRIBE employees;
 
-INSERT INTO employees (employee_id, last_name, first_name, title, title_of_courtesy, birth_date, hire_date, address, city, state, postal_code, country, region, home_phone, extension, photo, notes, reports_to, photo_path)
-VALUES (10, 'Foster', 'Connor', 'Sales Representative', 'Mr.', '1960-02-11', '1995-08-23', '18/281-287 Sussex St.', 'Sydney', NULL, 'NSW 2000', 'Australia', 4, '61 1800 671 823', '6942', NULL, 'Connor holds a dual BA in Business Management & Marketing', 5, NULL);
-
-UPDATE employees
-SET state = 'New South Wales'
-WHERE employee_id = 10;
-
 INSERT INTO orders
 VALUES (11077, 'SDYOH', 1);
 

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -219,16 +219,22 @@ JOIN order_details ON products.product_id = order_details.product_id
 JOIN orders ON order_details.order_id = orders.order_id
 WHERE orders.ship_region IS NOT NULL;
 
--- Update region in country to state
--- Update ship_region in orders to state
--- Add region to both tables; fill in with world regions
--- Add some orders with the APAC region
+
+--
+-- Change employee_id to unsigned tinyint; see how much space is saved
 SET SQL_SAFE_UPDATES = 1;
 
-SELECT * FROM orders
-ORDER BY ship_country, ship_city;
+SELECT * FROM employees;
+DESCRIBE employees;
 
-UPDATE orders
-SET ship_region = 1
-WHERE ship_country = 'Norway';
+INSERT INTO employees (employee_id, last_name, first_name, title, title_of_courtesy, birth_date, hire_date, address, city, state, postal_code, country, region, home_phone, extension, photo, notes, reports_to, photo_path)
+VALUES (10, 'Foster', 'Connor', 'Sales Representative', 'Mr.', '1960-02-11', '1995-08-23', '18/281-287 Sussex St.', 'Sydney', NULL, 'NSW 2000', 'Australia', 4, '61 1800 671 823', '6942', NULL, 'Connor holds a dual BA in Business Management & Marketing', 5, NULL);
 
+UPDATE employees
+SET state = 'New South Wales'
+WHERE employee_id = 10;
+
+INSERT INTO orders
+VALUES (11077, 'SDYOH', 1);
+
+SHOW CREATE TABLE orders;

--- a/northwind_queries.sql
+++ b/northwind_queries.sql
@@ -224,10 +224,21 @@ WHERE orders.ship_region IS NOT NULL;
 -- Change employee_id to unsigned tinyint; see how much space is saved
 SET SQL_SAFE_UPDATES = 1;
 
-SELECT * FROM employees;
-DESCRIBE employees;
+SELECT * FROM orders
+ORDER BY order_id DESC;
 
-INSERT INTO orders
-VALUES (11077, 'SDYOH', 1);
+SELECT * FROM order_details
+WHERE order_id = 10248;
+
+DESCRIBE orders;
 
 SHOW CREATE TABLE orders;
+
+SELECT * FROM shippers;
+
+INSERT INTO orders
+VALUES (11078, 'SDYOH', 10, '1996-12-01', '1997-01-01', '1996-12-03', 3, 70.50, 'Sydney Opera House', 'Bennelong Point', 'Sydney', 'New South Wales', 4, '2000', 'Australia');
+
+SELECT * FROM customers;
+
+DESCRIBE customers;


### PR DESCRIPTION
- Create the first order from the APAC region (order_id = 11078)
- Create the first employee from the APAC region (10)
- Create the first customer from the APAC region (customer_id = SDYOH)
- Update all LATAM countries in orders to use `ship_region` = 3 rather than 4
- Update `ship_region` of `ship_country` = 'Mexico` to 2